### PR TITLE
Fix truncated retry logic helper

### DIFF
--- a/EAF.AzureProvisioning/Private/retry-logic.psm1
+++ b/EAF.AzureProvisioning/Private/retry-logic.psm1
@@ -409,5 +409,52 @@ function Invoke-WithRetry {
     
 .EXAMPLE
     # Retry a resource deployment
-    $deployment = Invoke-AzCommandWithRetry -Command "New-AzResourceGroupDeployment" -
+    $deployment = Invoke-AzCommandWithRetry -Command "New-AzResourceGroupDeployment" -Parameters @{ \
+        ResourceGroupName = "mygroup" \
+        TemplateFile      = "template.bicep" \
+    } -MaxRetryCount 5
+
+#>
+
+function Invoke-AzCommandWithRetry {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Command,
+
+        [Parameter(Mandatory = $false)]
+        [hashtable]$Parameters = @{},
+
+        [Parameter(Mandatory = $false)]
+        [int]$MaxRetryCount = 3,
+
+        [Parameter(Mandatory = $false)]
+        [int]$BaseDelayMs = 1000,
+
+        [Parameter(Mandatory = $false)]
+        [int]$MaxDelayMs = 60000,
+
+        [Parameter(Mandatory = $false)]
+        [scriptblock]$RetryableErrorDetectionBlock,
+
+        [Parameter(Mandatory = $false)]
+        [switch]$ThrowOnLastError = $true
+    )
+
+    $scriptBlock = {
+        param($cmd, $params)
+        & $cmd @params
+    }
+
+    Invoke-WithRetry -ScriptBlock $scriptBlock `
+        -ArgumentList $Command, $Parameters `
+        -MaxRetryCount $MaxRetryCount `
+        -BaseDelayMs $BaseDelayMs `
+        -MaxDelayMs $MaxDelayMs `
+        -RetryableErrorDetectionBlock $RetryableErrorDetectionBlock `
+        -ThrowOnLastError:$ThrowOnLastError `
+        -ActivityName $Command
+}
+
+
 


### PR DESCRIPTION
## Summary
- implement missing `Invoke-AzCommandWithRetry` in `retry-logic.psm1`

## Testing
- `pwsh -NoLogo -File ./EAF.AzureProvisioning/Tests/Run-Tests.ps1` *(fails: `pwsh` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f556e7250832ca37c8be3a99c121e